### PR TITLE
fix(router-helpers): properly escape all regex special characters in normaliseSegment

### DIFF
--- a/packages/router-helpers/modules/__tests__/index.ts
+++ b/packages/router-helpers/modules/__tests__/index.ts
@@ -27,6 +27,31 @@ describe('router-helpers', function() {
             expect(helpers.startsWithSegment({ name: null } as any)('a')).toBe(false)
             expect(helpers.startsWithSegment({ name: undefined } as any, 'a')).toBe(false)
         })
+
+        it('should properly escape special regex characters in segments', function() {
+            // Test with backslashes
+            expect(helpers.startsWithSegment('a\\b.c', 'a\\b')).toBe(true)
+            expect(helpers.startsWithSegment('a\\b.c', 'a.b')).toBe(false)
+            
+            // Test with other special regex characters
+            expect(helpers.startsWithSegment('a$.b', 'a$')).toBe(true)
+            expect(helpers.startsWithSegment('a^.b', 'a^')).toBe(true)
+            expect(helpers.startsWithSegment('a*.b', 'a*')).toBe(true)
+            expect(helpers.startsWithSegment('a+.b', 'a+')).toBe(true)
+            expect(helpers.startsWithSegment('a?.b', 'a?')).toBe(true)
+            expect(helpers.startsWithSegment('a|.b', 'a|')).toBe(true)
+            expect(helpers.startsWithSegment('a(.b', 'a(')).toBe(true)
+            expect(helpers.startsWithSegment('a).b', 'a)')).toBe(true)
+            expect(helpers.startsWithSegment('a[.b', 'a[')).toBe(true)
+            expect(helpers.startsWithSegment('a].b', 'a]')).toBe(true)
+            expect(helpers.startsWithSegment('a{.b', 'a{')).toBe(true)
+            expect(helpers.startsWithSegment('a}.b', 'a}')).toBe(true)
+            
+            // Test that these don't match as regex patterns
+            expect(helpers.startsWithSegment('abc', 'a*')).toBe(false) // * should not match any character
+            expect(helpers.startsWithSegment('abc', 'a+')).toBe(false) // + should not match any character
+            expect(helpers.startsWithSegment('abc', 'a?')).toBe(false) // ? should not match any character
+        })
     })
 
     describe('.endsWithSegment()', function() {

--- a/packages/router-helpers/modules/index.ts
+++ b/packages/router-helpers/modules/index.ts
@@ -59,15 +59,16 @@ const test = (route: State | string, regex: RegExp): boolean => {
 }
 
 /**
- * Normalizes a route segment by escaping dots for use in regular expressions.
- * This ensures that dots in route names are treated as literal characters
- * rather than regex wildcards.
+ * Normalizes a route segment by escaping special regex characters.
+ * This ensures that special characters in route names are treated as literal characters
+ * rather than regex metacharacters.
  * 
  * @param name - The route segment name to normalize
- * @returns The normalized segment with escaped dots
+ * @returns The normalized segment with escaped special characters
  */
 const normaliseSegment = (name: string): string => {
-    return name.replace(/\./g, '\\.')
+    // Escape all regex special characters: \ ^ $ . | ? * + ( ) [ ] { }
+    return name.replace(/[\\^$.|?*+()[\]{}]/g, '\\$&')
 }
 
 /** Cache for compiled regular expressions to improve performance */


### PR DESCRIPTION
 - Fix incomplete string escaping security issue identified by CodeQL - Replace simple dot escaping with comprehensive regex character escaping - Escape backslashes, dots, and all other regex metacharacters - Add comprehensive tests for special character handling - Ensure route segments with special characters are treated as literals - Fixes: https://github.com/riogod/router/security/code-scanning/1