### PR TITLE
fix(transition): remove unused variable _titleRoute to resolve CodeQL warning

### DIFF
--- a/packages/router/modules/transition/index.ts
+++ b/packages/router/modules/transition/index.ts
@@ -227,13 +227,11 @@ export default function transition(
         
         // Find the most specific route that has a browserTitle
         let titleHandler = null
-        let _titleRoute = null
         
         for (let i = toStateIds.length - 1; i >= 0; i--) {
             const routeName = toStateIds[i]
             if (browserTitleFunctions[routeName]) {
                 titleHandler = browserTitleFunctions[routeName]
-                _titleRoute = routeName
                 break
             }
         }


### PR DESCRIPTION
 - Remove useless assignment to local variable _titleRoute in updateBrowserTitle function - Variable was assigned routeName value but never used afterwards - Fixes CodeQL alert #2: Useless assignment to local variable - Maintains same functionality while improving code quality - Fixes: https://github.com/riogod/router/security/code-scanning/2