### PR TITLE
fix(router): resolve cloneRouter shared rootNode issue - Add clone()

### DIFF
--- a/packages/router/modules/__tests__/clone.ts
+++ b/packages/router/modules/__tests__/clone.ts
@@ -10,7 +10,9 @@ describe('core/clone', () => {
 
         const clonedRouter = cloneRouter(router)
 
-        expect(clonedRouter.rootNode).toBe(router.rootNode)
+        expect(clonedRouter.rootNode).not.toBe(router.rootNode)
+        expect(clonedRouter.rootNode.name).toBe(router.rootNode.name)
+        expect(clonedRouter.rootNode.path).toBe(router.rootNode.path)
     })
 
     it('should clone plugins', () => {
@@ -61,4 +63,50 @@ describe('core/clone', () => {
             canDeactivateAdmin
         );
     });
+
+    it('should allow adding same routes to different cloned routers without conflict', () => {
+        const router = createTestRouter()
+        
+        const router1 = cloneRouter(router)
+        const router2 = cloneRouter(router)
+
+        // This should not throw an error, but currently it does due to shared rootNode
+        expect(() => {
+            router1.add([{ name: "foo", path: "/foo" }])
+            router2.add([{ name: "foo", path: "/foo" }])
+        }).not.toThrow()
+    })
+
+    it('should allow independent route modifications in cloned routers', () => {
+        const router = createTestRouter()
+        
+        const router1 = cloneRouter(router)
+        const router2 = cloneRouter(router)
+
+        // Add different routes to each cloned router
+        router1.add([
+            { name: "dashboard", path: "/dashboard" },
+            { name: "dashboard.stats", path: "/stats" }
+        ])
+        
+        router2.add([
+            { name: "blog", path: "/blog" },
+            { name: "blog.post", path: "/post/:id" }
+        ])
+
+        // Each router should only have its own routes
+        expect(router1.buildPath('dashboard')).toBe('/dashboard')
+        expect(router1.buildPath('dashboard.stats')).toBe('/dashboard/stats')
+        expect(() => router1.buildPath('blog')).toThrow()
+        expect(() => router1.buildPath('blog.post')).toThrow()
+
+        expect(router2.buildPath('blog')).toBe('/blog')
+        expect(router2.buildPath('blog.post', { id: '123' })).toBe('/blog/post/123')
+        expect(() => router2.buildPath('dashboard')).toThrow()
+        expect(() => router2.buildPath('dashboard.stats')).toThrow()
+
+        // Original router should not be affected
+        expect(() => router.buildPath('dashboard')).toThrow()
+        expect(() => router.buildPath('blog')).toThrow()
+    })
 })

--- a/packages/router/modules/clone.ts
+++ b/packages/router/modules/clone.ts
@@ -35,7 +35,7 @@ export default function cloneRouter<
     Dependencies extends DefaultDependencies = DefaultDependencies
 >(router: Router, dependencies?: Dependencies): Router<Dependencies> {
     const clonedRouter = createRouter<Dependencies>(
-        router.rootNode,
+        router.rootNode.clone(),
         router.getOptions(),
         dependencies
     )


### PR DESCRIPTION
Add clone() method to RouteNode for deep copying route tree structure - Update cloneRouter to use rootNode.clone() instead of sharing reference - Fix bug where multiple cloned routers shared same rootNode causing conflicts - Add comprehensive tests for independent route modifications in cloned routers - Ensure cloned routers can add same route names without conflicts - Maintain backward compatibility while fixing shared state issue - Fixes #16: cloneRouter uses same root node